### PR TITLE
Always initialize timeout value

### DIFF
--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -97,10 +97,6 @@ int RestClient::request(const char* method, String path, String body){
     client->print(requestString);
     HTTP_DEBUG_PRINT(requestString);
 
-    // make sure you've sent all bytes. Ugly hack.
-    // TODO: check output buffer instead?
-    delay(50);
-
     HTTP_DEBUG_PRINT("HTTP: call getResponse\n");
     int statusCode = getResponse();
     HTTP_DEBUG_PRINT("HTTP: return getResponse\n");

--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -11,14 +11,8 @@
 #endif
 
 
-RestClient::RestClient(Client& netClient, const char* _host) {
-  host = _host;
-  port = 80;
-  num_headers = 0;
-  contentType = "x-www-form-urlencoded";	// default
-  this->client = &netClient;
-  this->responseBody = "";
-  this->timeout = 1000;     // default. TODO: add a setter function
+RestClient::RestClient(Client& netClient, const char* _host) : 
+  RestClient(netClient, _host, 80) {
 }
 
 RestClient::RestClient(Client& netClient, const char* _host, int _port) {
@@ -27,6 +21,8 @@ RestClient::RestClient(Client& netClient, const char* _host, int _port) {
   num_headers = 0;
   contentType = "application/x-www-form-urlencoded";	// default
   this->client = &netClient;
+  this->responseBody = "";
+  this->timeout = 1000;     // default. TODO: add a setter function
 }
 
 // GET path

--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -22,7 +22,7 @@ RestClient::RestClient(Client& netClient, const char* _host, int _port) {
   contentType = "application/x-www-form-urlencoded";	// default
   this->client = &netClient;
   this->responseBody = "";
-  this->timeout = 1000;     // default. TODO: add a setter function
+  this->timeout = 10000;     // default. TODO: add a setter function
 }
 
 // GET path


### PR DESCRIPTION
Without this patch `RestClient(Client& netClient, const char* _host)` was the only constructor to initialize `this->timeout`, so if `RestClient(Client& netClient, const char* _host, int _port)` was used it would have a timeout of 0 causing issues like #7.

This patch:
- reduces duplication in the constructors, ensures timeout is always set (resolves #7)
- bumps the default timeout to 10s (previous was 1s)
- removes an unnecessary delay in the library

cc/ @tigoe @don 
