### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/full_test_suite/full_test_suite.ino
+++ b/examples/full_test_suite/full_test_suite.ino
@@ -12,7 +12,7 @@
 #include "config.h"
 
 int test_delay = 1000; //so we don't spam the API
-boolean describe_tests = true;
+bool describe_tests = true;
 
 char serverAddress[] = "192.168.0.3";  // server address
 int port = 8080;


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633