### PR TITLE
return correct status code instead of 0 after timeout

### DIFF
--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -182,7 +182,7 @@ int RestClient::getResponse() {
     } else {
       // there is a condition where client connects
       // and available() always <= 0. So timeout is here to catch that:
-      if (millis() - this->requestStart > this->timeout) return 0;
+      if (millis() - this->requestStart > this->timeout) return code;
     }
   }
 


### PR DESCRIPTION
Changed a hardcoded 0 with code to return the correct response status after connection timeout.

I encountered the problem after a POST request got status 0, but non empty response body.